### PR TITLE
allow to pass kernel options and manager options to panther driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,16 @@
             "email": "robertfreigang@gmx.de"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/phcorp/mink-panther-driver"
+        }
+    ],
     "require": {
         "php": ">=7.1",
         "behat/behat": "^3.0.5",
-        "robertfausk/mink-panther-driver": "^1.0",
+        "robertfausk/mink-panther-driver": "dev-feat/all-panther-options",
         "symfony/config": "^3.4|^4.0|^5.0",
         "friends-of-behat/mink-extension": "^2.3.0"
     },

--- a/src/ServiceContainer/Driver/PantherFactory.php
+++ b/src/ServiceContainer/Driver/PantherFactory.php
@@ -36,6 +36,8 @@ class PantherFactory implements DriverFactory
     {
         $configuration = new PantherConfiguration();
         $builder->append($configuration->addOptionsNode());
+        $builder->append($configuration->addKernelOptionsNode());
+        $builder->append($configuration->addManagerOptionsNode());
     }
 
     /**
@@ -53,6 +55,8 @@ class PantherFactory implements DriverFactory
             'Behat\Mink\Driver\PantherDriver',
             array(
                 $config['options'] ?? [],
+                $config['kernel_options'] ?? [],
+                $config['manager_options'] ?? [],
             )
         );
     }

--- a/src/ServiceContainer/PantherConfiguration.php
+++ b/src/ServiceContainer/PantherConfiguration.php
@@ -24,7 +24,11 @@ class PantherConfiguration implements ConfigurationInterface
             $root = $treeBuilder->root('panther');
         }
 
-        $root->append($this->addOptionsNode());
+        $root->children()
+            ->append($this->addOptionsNode())
+            ->append($this->addKernelOptionsNode())
+            ->append($this->addManagerOptionsNode())
+        ->end();
 
         return $treeBuilder;
     }
@@ -42,6 +46,50 @@ class PantherConfiguration implements ConfigurationInterface
         $node = $root
             ->info(
                 "These are the options passed as first argument to PantherTestCaseTrait::createPantherClient client constructor."
+            )
+            ->ignoreExtraKeys()
+            ->scalarPrototype()
+            ->end()
+        ;
+
+        return $node;
+    }
+
+    public function addKernelOptionsNode(): ArrayNodeDefinition
+    {
+        $treeBuilder = new TreeBuilder('kernel_options');
+
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $root = $treeBuilder->getRootNode();
+        } else {
+            $root = $treeBuilder->root('kernel_options');
+        }
+
+        $node = $root
+            ->info(
+                "These are the options passed as second argument to PantherTestCaseTrait::createPantherClient client constructor."
+            )
+            ->ignoreExtraKeys()
+            ->scalarPrototype()
+            ->end()
+        ;
+
+        return $node;
+    }
+
+    public function addManagerOptionsNode(): ArrayNodeDefinition
+    {
+        $treeBuilder = new TreeBuilder('manager_options');
+
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $root = $treeBuilder->getRootNode();
+        } else {
+            $root = $treeBuilder->root('manager_options');
+        }
+
+        $node = $root
+            ->info(
+                "These are the options passed as third argument to PantherTestCaseTrait::createPantherClient client constructor."
             )
             ->ignoreExtraKeys()
             ->scalarPrototype()

--- a/tests/Unit/PantherConfigurationTest.php
+++ b/tests/Unit/PantherConfigurationTest.php
@@ -68,6 +68,8 @@ class PantherConfigurationTest extends TestCase
                 'options' => [
                     'hostname' => '127.0.0.1',
                 ],
+                'kernel_options' => [],
+                'manager_options' => [],
             ]
         );
     }


### PR DESCRIPTION
This fixes #5 

PR on robertfausk/mink-panther-driver: https://github.com/robertfausk/mink-panther-driver/pull/20

## Testing the pull-request

update your composer.json with following values :

```json
{
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/phcorp/behat-panther-extension"
        },
        {
            "type": "vcs",
            "url": "https://github.com/phcorp/mink-panther-driver"
        }
    ],
    "require-dev": {
        "robertfausk/behat-panther-extension": "dev-feat/all-panther-options"
    }
}
```

and run `$ composer update robertfausk/behat-panther-extension`

update your behat.yaml, for instance:

```yaml
default:
    extensions:
        Robertfausk\Behat\PantherExtension: ~
        Behat\MinkExtension:
            sessions:
                my_session:
                    panther:
                        options:
                            browser: 'chrome'
                        manager_options:
                            connection_timeout_in_ms: 5000
                            request_timeout_in_ms: 120000
```

then lanch your tests suites (e.g. `APP_ENV=test bin/behat`)

additional options should be taken into account

## Merging

A new version of mink-panther-driver sould be released first (see https://github.com/robertfausk/mink-panther-driver/pull/20).

Commit https://github.com/robertfausk/behat-panther-extension/pull/6/commits/c717075fef6098e9fbc9230322d9b5551e75c5cd should be omitted before merging.