### PR TITLE
feat: add PHP 8.5 service to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,3 +72,12 @@ services:
         - PHP_VERSION=8.4
     volumes:
       - .:/var/www/html
+
+  php8.5:
+    tty: true
+    build:
+      context: .
+      args:
+        - PHP_VERSION=8.5
+    volumes:
+      - .:/var/www/html


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` file to add support for running a PHP 8.5 service in the development environment.

Environment configuration:

* Added a new `php8.5` service to `docker-compose.yml` with build arguments for PHP version 8.5 and mounted the project directory as a volume.