### PR TITLE
fix: docker warning, legacy key/value format with whitespace separator should not be used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && apt-get install -y \
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
-ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV COMPOSER_HOME /home/docker/.composer
+ENV COMPOSER_ALLOW_SUPERUSER=1
+ENV COMPOSER_HOME=/home/docker/.composer
 # contains dev-mode packages
 RUN composer global config --no-plugins allow-plugins.pyrech/composer-changelogs true
 RUN if php -r 'exit(version_compare(PHP_VERSION, "8.0", ">=") ? 0 : 1);'; then \
@@ -27,7 +27,7 @@ RUN if php -r 'exit(version_compare(PHP_VERSION, "8.0", ">=") ? 0 : 1);'; then \
 # add symfony/panther
 ##############################################################
 RUN apt-get update && apt-get install -y libzip-dev zlib1g-dev unzip chromium && docker-php-ext-install zip
-ENV PANTHER_NO_SANDBOX 1
+ENV PANTHER_NO_SANDBOX=1
 
 ##############################################################
 # add gd


### PR DESCRIPTION

This pull request makes minor improvements to the Dockerfile by updating the syntax for environment variable definitions to use the `KEY=VALUE` format, which is the recommended and more explicit style for Dockerfiles.

Solves warning:

`Legacy key/value format with whitespace separator should not be used ("ENV key=value" should be used instead of legacy "ENV key value" format)`
Docker DX (docker-language-server) [LegacyKeyValueFormat](https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/)


- **Dockerfile environment variable formatting:**
  * Changed the `ENV` statements for `COMPOSER_ALLOW_SUPERUSER`, `COMPOSER_HOME`, and `PANTHER_NO_SANDBOX` to use the `KEY=VALUE` format instead of separate arguments. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L16-R17) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L30-R30)