### PR TITLE
feat: bump github CI to use PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
         symfony: ['symfony3', 'symfony4', 'symfony5']
         include:
           - php: '8.1'
@@ -30,6 +30,9 @@ jobs:
             symfony: 'symfony7'
           - php: '8.4'
             symfony: 'symfony7'
+          - php: '8.5'
+            symfony: 'symfony7'
+
       fail-fast: false
     env:
       MATRIX_PHP: ${{ matrix.php }}
@@ -37,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - name: Setup PHP


### PR DESCRIPTION
Updates the CI workflow to improve compatibility and keep dependencies up to date. The most significant changes are the addition of PHP 8.5 to the test matrix and updating the GitHub Actions checkout version.

**CI compatibility and dependency updates:**

* Added PHP 8.5 to the test matrix in `.github/workflows/ci.yml`, ensuring the project is tested against the latest PHP version.
* Included a new matrix entry for PHP 8.5 with Symfony 7 in `.github/workflows/ci.yml`.
* Updated the GitHub Actions `checkout` step from version 4 to version 5 in `.github/workflows/ci.yml` for improved reliability and features.