### PR TITLE
feat: simplify useless variable and if else to ternary

### DIFF
--- a/src/ServiceContainer/PantherConfiguration.php
+++ b/src/ServiceContainer/PantherConfiguration.php
@@ -18,11 +18,7 @@ class PantherConfiguration implements ConfigurationInterface
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('panther');
-        if (\method_exists($treeBuilder, 'getRootNode')) {
-            $root = $treeBuilder->getRootNode();
-        } else {
-            $root = $treeBuilder->root('panther');
-        }
+        $root = \method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('panther');
 
         $root->children()
             ->append($this->addOptionsNode())
@@ -36,45 +32,29 @@ class PantherConfiguration implements ConfigurationInterface
     public function addOptionsNode(): ArrayNodeDefinition
     {
         $treeBuilder = new TreeBuilder('options');
+        $root = \method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('options');
 
-        if (\method_exists($treeBuilder, 'getRootNode')) {
-            $root = $treeBuilder->getRootNode();
-        } else {
-            $root = $treeBuilder->root('options');
-        }
-
-        $node = $root
+        return $root
             ->info(
                 "These are the options passed as first argument to PantherTestCaseTrait::createPantherClient client constructor."
             )
             ->ignoreExtraKeys()
             ->variablePrototype()
-            ->end()
-        ;
-
-        return $node;
+            ->end();
     }
 
     public function addKernelOptionsNode(): ArrayNodeDefinition
     {
         $treeBuilder = new TreeBuilder('kernel_options');
+        $root = \method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('kernel_options');
 
-        if (\method_exists($treeBuilder, 'getRootNode')) {
-            $root = $treeBuilder->getRootNode();
-        } else {
-            $root = $treeBuilder->root('kernel_options');
-        }
-
-        $node = $root
+        return $root
             ->info(
                 "These are the options passed as second argument to PantherTestCaseTrait::createPantherClient client constructor."
             )
             ->ignoreExtraKeys()
             ->scalarPrototype()
-            ->end()
-        ;
-
-        return $node;
+            ->end();
     }
 
     public function addManagerOptionsNode(): ArrayNodeDefinition
@@ -87,15 +67,12 @@ class PantherConfiguration implements ConfigurationInterface
             $root = $treeBuilder->root('manager_options');
         }
 
-        $node = $root
+        return $root
             ->info(
                 "These are the options passed as third argument to PantherTestCaseTrait::createPantherClient client constructor."
             )
             ->ignoreExtraKeys()
             ->variablePrototype()
-            ->end()
-        ;
-
-        return $node;
+            ->end();
     }
 }


### PR DESCRIPTION
Refactors the `PantherConfiguration` class to simplify and streamline the way configuration tree nodes are created. The main focus is on reducing code duplication and improving readability when handling Symfony's `TreeBuilder` API.

Refactoring and simplification of configuration tree node creation:

* Consolidated the logic for retrieving the root node from a `TreeBuilder` by using a ternary expression instead of repeated `if` statements throughout the `getConfigTreeBuilder`, `addOptionsNode`, `addKernelOptionsNode`, and `addManagerOptionsNode` methods. [[1]](diffhunk://#diff-c34200b8508e9974fb0f4764bc3fc00b543d6c9e8714d783e13097aaaeec4619L21-R21) [[2]](diffhunk://#diff-c34200b8508e9974fb0f4764bc3fc00b543d6c9e8714d783e13097aaaeec4619R35-R57) [[3]](diffhunk://#diff-c34200b8508e9974fb0f4764bc3fc00b543d6c9e8714d783e13097aaaeec4619L90-R76)
* Simplified the return value of node-building methods to return the configured root node directly, removing unnecessary intermediate variables and redundant code. [[1]](diffhunk://#diff-c34200b8508e9974fb0f4764bc3fc00b543d6c9e8714d783e13097aaaeec4619R35-R57) [[2]](diffhunk://#diff-c34200b8508e9974fb0f4764bc3fc00b543d6c9e8714d783e13097aaaeec4619L90-R76)